### PR TITLE
fix: 대시보드·저장소 링크를 PyTorchKR 조직으로 갱신

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@
 
 | 유형 | 이슈 템플릿 |
 |------|------------|
-| 모델 | [➕ 모델 추가](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-model.yml) |
-| 데이터셋 | [➕ 데이터셋 추가](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-dataset.yml) |
-| 시뮬레이터 | [➕ 시뮬레이터 추가](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-simulator.yml) |
+| 모델 | [➕ 모델 추가](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-model.yml) |
+| 데이터셋 | [➕ 데이터셋 추가](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-dataset.yml) |
+| 시뮬레이터 | [➕ 시뮬레이터 추가](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-simulator.yml) |
 
 이슈를 등록하면 봇이 자동으로 PR을 생성합니다. 관리자가 검토 후 머지합니다.
 
@@ -150,9 +150,9 @@ There are two types of contributions:
 
 | Type | Template |
 |------|----------|
-| Model | [➕ Add a Model](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-model.yml) |
-| Dataset | [➕ Add a Dataset](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-dataset.yml) |
-| Simulator | [➕ Add a Simulator](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-simulator.yml) |
+| Model | [➕ Add a Model](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-model.yml) |
+| Dataset | [➕ Add a Dataset](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-dataset.yml) |
+| Simulator | [➕ Add a Simulator](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-simulator.yml) |
 
 A bot will automatically open a PR from your issue. Maintainers will review and merge.
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 > 🤖 Physical AI (Robotics & Embodied AI) 분야의 오픈소스 모델, 데이터셋, 시뮬레이터를 체계적으로 정리한 큐레이션 리스트.
 > A curated list of open-source models, datasets, and simulators for Physical AI (Robotics & Embodied AI).
 
-[![Models](https://img.shields.io/badge/Models-14-blue)](https://pytorchkorea.github.io/Awesome-Physical-AI)
-[![Datasets](https://img.shields.io/badge/Datasets-11-green)](https://pytorchkorea.github.io/Awesome-Physical-AI)
-[![Simulators](https://img.shields.io/badge/Simulators-9-purple)](https://pytorchkorea.github.io/Awesome-Physical-AI)
-[![Organizations](https://img.shields.io/badge/Organizations-30-orange)](https://pytorchkorea.github.io/Awesome-Physical-AI)
-[![Updated](https://img.shields.io/badge/Updated-2026-06-29-lightgrey)](https://github.com/PyTorchKorea/Awesome-Physical-AI)
-[![Dashboard](https://img.shields.io/badge/🌐_Dashboard-Live-brightgreen)](https://pytorchkorea.github.io/Awesome-Physical-AI)
+[![Models](https://img.shields.io/badge/Models-14-blue)](https://pytorchkr.github.io/Awesome-Physical-AI)
+[![Datasets](https://img.shields.io/badge/Datasets-11-green)](https://pytorchkr.github.io/Awesome-Physical-AI)
+[![Simulators](https://img.shields.io/badge/Simulators-9-purple)](https://pytorchkr.github.io/Awesome-Physical-AI)
+[![Organizations](https://img.shields.io/badge/Organizations-30-orange)](https://pytorchkr.github.io/Awesome-Physical-AI)
+[![Updated](https://img.shields.io/badge/Updated-2026-06-29-lightgrey)](https://github.com/PyTorchKR/Awesome-Physical-AI)
+[![Dashboard](https://img.shields.io/badge/🌐_Dashboard-Live-brightgreen)](https://pytorchkr.github.io/Awesome-Physical-AI)
 
-> **[👉 인터랙티브 대시보드에서 필터링 및 시각화 보기 | View Interactive Dashboard](https://pytorchkorea.github.io/Awesome-Physical-AI)**
+> **[👉 인터랙티브 대시보드에서 필터링 및 시각화 보기 | View Interactive Dashboard](https://pytorchkr.github.io/Awesome-Physical-AI)**
 
 ---
 
@@ -90,9 +90,9 @@
 새 항목을 추가하려면 GitHub Issue를 열어주세요.
 To add a new entry, please open a GitHub Issue:
 
-- **[➕ Add a Model](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-model.yml)**
-- **[➕ Add a Dataset](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-dataset.yml)**
-- **[➕ Add a Simulator](https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-simulator.yml)**
+- **[➕ Add a Model](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-model.yml)**
+- **[➕ Add a Dataset](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-dataset.yml)**
+- **[➕ Add a Simulator](https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-simulator.yml)**
 
 이슈가 등록되면 봇이 자동으로 PR을 생성하고, 관리자가 검토 후 머지합니다.
 A bot will automatically create a PR from your issue for admin review.

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
 <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-900/90 backdrop-blur border-b border-gray-200 dark:border-gray-800">
   <div class="max-w-7xl mx-auto px-4 h-14 flex items-center gap-4">
     <!-- Logo -->
-    <a href="https://github.com/PyTorchKorea/Awesome-Physical-AI" target="_blank"
+    <a href="https://github.com/PyTorchKR/Awesome-Physical-AI" target="_blank"
        class="flex items-center gap-2 font-bold text-lg shrink-0">
       <span class="text-2xl">🤖</span>
       <span class="hidden sm:inline">Awesome <span class="text-brand-500">Physical AI</span></span>
@@ -101,7 +101,7 @@
       </button>
 
       <!-- GitHub -->
-      <a href="https://github.com/PyTorchKorea/Awesome-Physical-AI" target="_blank"
+      <a href="https://github.com/PyTorchKR/Awesome-Physical-AI" target="_blank"
          class="text-sm px-3 py-1.5 rounded-lg bg-gray-900 dark:bg-gray-700 text-white
                 hover:bg-gray-700 dark:hover:bg-gray-600 transition-colors flex items-center gap-1.5">
         <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
@@ -557,17 +557,17 @@
     <p class="text-sm text-gray-600 dark:text-gray-400 mb-4"
        x-text="lang === 'ko' ? '이슈를 등록하면 자동으로 PR이 생성됩니다. 관리자 검토 후 추가됩니다.' : 'Open an issue and a PR will be created automatically for admin review.'"></p>
     <div class="flex gap-3 justify-center flex-wrap">
-      <a href="https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-model.yml"
+      <a href="https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-model.yml"
          target="_blank"
          class="px-4 py-2 rounded-lg bg-brand-500 hover:bg-brand-600 text-white text-sm font-medium transition-colors">
         ➕ <span x-text="lang === 'ko' ? '모델 추가' : 'Add Model'"></span>
       </a>
-      <a href="https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-dataset.yml"
+      <a href="https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-dataset.yml"
          target="_blank"
          class="px-4 py-2 rounded-lg bg-green-600 hover:bg-green-700 text-white text-sm font-medium transition-colors">
         ➕ <span x-text="lang === 'ko' ? '데이터셋 추가' : 'Add Dataset'"></span>
       </a>
-      <a href="https://github.com/PyTorchKorea/Awesome-Physical-AI/issues/new?template=add-simulator.yml"
+      <a href="https://github.com/PyTorchKR/Awesome-Physical-AI/issues/new?template=add-simulator.yml"
          target="_blank"
          class="px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium transition-colors">
         ➕ <span x-text="lang === 'ko' ? '시뮬레이터 추가' : 'Add Simulator'"></span>

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -21,8 +21,8 @@ README_PATH = ROOT / "README.md"
 TODAY = date.today().isoformat()
 
 BADGE_BASE = "https://img.shields.io/badge"
-REPO_URL = "https://github.com/PyTorchKorea/Awesome-Physical-AI"
-DASHBOARD_URL = "https://pytorchkorea.github.io/Awesome-Physical-AI"
+REPO_URL = "https://github.com/PyTorchKR/Awesome-Physical-AI"
+DASHBOARD_URL = "https://pytorchkr.github.io/Awesome-Physical-AI"
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
조직명 변경(PyTorchKorea → PyTorchKR)으로 GitHub Pages 대시보드 주소가 pytorchkr.github.io 로 이동해 기존 링크가 열리지 않던 문제 수정.

- generate_site.py: REPO_URL / DASHBOARD_URL 갱신 (README 재생성 원본)
- docs/index.html, CONTRIBUTING.md, README.md: 저장소·이슈 링크 갱신